### PR TITLE
Change visibility of the constructor of DomainMapper

### DIFF
--- a/urm-core/src/main/java/com/iluwatar/urm/DomainMapper.java
+++ b/urm-core/src/main/java/com/iluwatar/urm/DomainMapper.java
@@ -24,7 +24,7 @@ public class DomainMapper {
   private final List<Class<?>> classes;
   private final Presenter presenter;
 
-  DomainMapper(Presenter presenter, final List<Class<?>> classes) {
+  public DomainMapper(Presenter presenter, final List<Class<?>> classes) {
     this.presenter = presenter;
     this.classes = classes;
     fieldScanner = new FieldScanner(classes);


### PR DESCRIPTION
Change visibility of the constructor of DomainMapper to public, so when using the urm core as a dependency I am able to generate diagrams from a list of classes